### PR TITLE
Kat filtering results

### DIFF
--- a/lib/device_info_page.dart
+++ b/lib/device_info_page.dart
@@ -279,9 +279,18 @@ class _DeviceInfoPageState extends State<DeviceInfoPage> {
     // If the bluetooth connection state changes, run code to change UI
     return StreamBuilder<BluetoothConnectionState>(
       stream: widget.device.connectionState,
-      initialData: BluetoothConnectionState.disconnected,
       builder: (context, snapshot) {
         final state = snapshot.data;
+
+        // blank screen if data not received yet
+        if (_isConnecting) {
+          return const Scaffold(
+            body: Center(
+              child: CircularProgressIndicator(),
+            ),
+          ); 
+        }
+
 
       // display right page depending of if the device is connected
         if (state == BluetoothConnectionState.connected) { 
@@ -399,7 +408,21 @@ class _DeviceInfoPageState extends State<DeviceInfoPage> {
   Widget _buildDisconnectedUI() {
     return Scaffold(
       body: Center(
-        child: Text("disconnected"))
+        child: Column( 
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text("disconnected"),
+            const SizedBox(height: 8),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton( // back button
+                onPressed: () => Navigator.of(context).pop(), 
+                child: const Text('Back'),
+              ),
+            ),
+          ],
+      ),
+      ),
     );
   }
 }

--- a/lib/device_info_page.dart
+++ b/lib/device_info_page.dart
@@ -276,6 +276,25 @@ class _DeviceInfoPageState extends State<DeviceInfoPage> {
 
   @override
   Widget build(BuildContext context) {
+    // If the bluetooth connection state changes, run code to change UI
+    return StreamBuilder<BluetoothConnectionState>(
+      stream: widget.device.connectionState,
+      initialData: BluetoothConnectionState.disconnected,
+      builder: (context, snapshot) {
+        final state = snapshot.data;
+
+      // display right page depending of if the device is connected
+        if (state == BluetoothConnectionState.connected) { 
+          return _buildConnectedUI();
+        } else {
+          return _buildDisconnectedUI();
+        }
+      }
+    );
+  }
+
+  // if the device is connected, share device info
+  Widget _buildConnectedUI() {
     final deviceName = widget.device.platformName.isNotEmpty
         ? widget.device.platformName
         : 'Unknown device';
@@ -373,6 +392,14 @@ class _DeviceInfoPageState extends State<DeviceInfoPage> {
                 ],
               ),
       ),
+    );
+  }
+
+  // sends you to screen with disconnected text
+  Widget _buildDisconnectedUI() {
+    return Scaffold(
+      body: Center(
+        child: Text("disconnected"))
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -140,7 +140,8 @@ class _BleDeviceListPageState extends State<BleDeviceListPage> {
                 final results = snapshot.data ?? const [];
 
                 for (final r in results) {
-                  if (r.rssi > -45) { // only show devices super close
+                  // scanned devices show if they are super close or already connected
+                  if (r.rssi > -45 || r.device.isConnected) { 
                     _latestByDevice[r.device.remoteId] = r;
                   }
                 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -140,7 +140,9 @@ class _BleDeviceListPageState extends State<BleDeviceListPage> {
                 final results = snapshot.data ?? const [];
 
                 for (final r in results) {
-                  _latestByDevice[r.device.remoteId] = r;
+                  if (r.rssi > -45) { // only show devices super close
+                    _latestByDevice[r.device.remoteId] = r;
+                  }
                 }
 
                 final devices = _latestByDevice.values.toList()
@@ -161,6 +163,8 @@ class _BleDeviceListPageState extends State<BleDeviceListPage> {
                   separatorBuilder: (_, _) => const Divider(height: 1),
                   itemBuilder: (context, index) {
                     final r = devices[index];
+                    
+
                     final name =
                         r.advertisementData.advName.trim().isNotEmpty
                             ? r.advertisementData.advName.trim()


### PR DESCRIPTION
updates:
- filtering devices based on how close they are. When you scan, it will only show devices that are like 2 feet away from you atm.
- Disconnects to device if the signal is not found. If it's the phone's side, it's much faster in showing up as disconnected. If the device disconnects it'll take a little time before it actually says disconnecting bc its looking for a connection.
- Added the disconnect screen with a back button
- Added a little loading symbol before it connects to the device bc originally it auto'd to disconnect since it was technically not connected yet at it looked a little jank. Sometimes the loading will take a little longer so I might add a back button for this too? or just press the phone's back button and it takes u back to the home page.
